### PR TITLE
docs: add architecture compass and refactor plan

### DIFF
--- a/docs/architecture-refactor.md
+++ b/docs/architecture-refactor.md
@@ -1,0 +1,418 @@
+# Architecture Refactor Plan
+
+> Plano para alinhar o projeto com os padrões do [Compass](compass/index.md).
+> Este documento é apenas um plano. Nada será implementado até aprovação.
+
+---
+
+## 1. Routing — Tudo deveria ser CRUD
+
+**Problema**: Rotas manuais com `get/post/put/delete` em vez de `resources`. Rotas duplicadas (habits declarados manualmente E com `resources`). URLs com hifens (`habits-check`) em vez de underscores.
+
+**Arquivo**: `config/routes.rb`
+
+**Antes**:
+```ruby
+get 'habits/:id', to: 'habits#show'
+get 'habits', to: 'habits#index'
+post 'habits', to: 'habits#create'
+put 'habits/:id', to: 'habits#update'
+delete 'habits/:id', to: 'habits#destroy'
+resources :habits  # DUPLICADO!
+
+get 'habits-check', to: 'habits_check#all'
+get 'habits-check/:habit_id', to: 'habits_check#index'
+post 'habits-check/:habit_id', to: 'habits_check#create'
+
+post 'checkout/create', to: 'checkout#create'
+post 'subscription/cancel', to: 'subscription#cancel'
+post 'subscription/create_session', to: 'subscription#create_session'
+```
+
+**Depois**:
+```ruby
+namespace :api do
+  namespace :v1 do
+    scope module: :private do
+      resource :me, only: [:show, :update], controller: 'me'
+      resources :habits do
+        resources :checks, controller: 'habits_check', only: [:index, :show, :create, :update]
+      end
+      resources :checks, controller: 'habits_check', only: [:index]  # GET /checks (all)
+      resources :habits_categories, only: [:index, :create, :update, :destroy]
+      resources :moods
+      resources :plans, only: [:index]
+      resource :checkout, only: [:create]
+      resource :subscription, only: [:show] do
+        resource :cancellation, only: [:create]     # POST cancel
+        resource :session, only: [:create]           # POST create_session
+      end
+    end
+
+    scope module: :public do
+      resource :sign_in, only: [:create], controller: 'auth/sign_in'
+      resource :sign_up, only: [:create], controller: 'auth/sign_up'
+      resource :siwe, only: [:show, :create], controller: 'auth/siwe'    # GET nonce, POST verify
+      resource :google_auth, only: [:create], controller: 'auth/google'
+    end
+
+    scope module: :internal do
+      resource :stripe_webhook, only: [:create]
+    end
+  end
+end
+```
+
+**Mudanças-chave**:
+- Remover rotas duplicadas de habits
+- `habits-check` → nested resource `habits/:habit_id/checks`
+- `subscription/cancel` → `subscription/cancellation` (noun, not verb)
+- `subscription/create_session` → `subscription/session` (CRUD)
+- `auth/sign-in` e `auth/sign-up` → resources separados
+- `namespace` em vez de `scope` para API versionamento correto
+
+---
+
+## 2. Controllers — Gordos demais, lógica de negócio vazando
+
+### 2.1 `ApplicationController` — Auth não deveria estar aqui
+
+**Problema**: `authorize_request` e `check_subscription` estão no `ApplicationController`, mas só são usados por controllers privados. Isso polui o controller base.
+
+**Solução**: Mover `authorize_request` e `check_subscription` para dentro do concern `ActiveAndAuthorized`. O `ApplicationController` deve ser mínimo.
+
+**Arquivo**: `app/controllers/application_controller.rb`
+
+**Antes**: Auth + subscription logic no ApplicationController
+**Depois**: `ApplicationController` só com `ActionController::API` (não `ActionController::Base`!) e configuração global.
+
+Bonus: Trocar `ActionController::Base` por `ActionController::API` — é uma API, não precisa de CSRF, cookies, sessions.
+
+### 2.2 `AuthController` — 230 linhas, 4 auth methods, zero extração
+
+**Problema**: Um único controller com `sign_in`, `sign_up`, `start_siwe_auth`, `siwe_verify`, `google_auth`. Cada método tem 30-60 linhas de business logic inline. Viola "thin controllers".
+
+**Solução**: Separar em controllers por método de auth:
+- `Public::Auth::SignInController` — email/password sign in
+- `Public::Auth::SignUpController` — email/password sign up
+- `Public::Auth::SiweController` — SIWE nonce + verify
+- `Public::Auth::GoogleController` — Google OAuth
+
+Extrair lógica para o model `Account`:
+```ruby
+class Account
+  def self.authenticate_with_email(email, password)
+    account = find_by(email: email)
+    account if account&.authenticate(password)
+  end
+
+  def self.find_or_create_from_google(payload)
+    # lógica de merge por google_id/email
+  end
+
+  def self.find_or_create_from_siwe(address)
+    # lógica de find_or_create_by world_address
+  end
+
+  def generate_jwt
+    JWT.encode({ account_id: id }, ENV['JWT_SECRET'], 'HS256')
+  end
+
+  def ensure_provider(provider)
+    unless connected_providers.include?(provider)
+      connected_providers << provider
+      save!
+    end
+  end
+end
+```
+
+### 2.3 `CheckoutController` — 95 linhas de Stripe logic inline
+
+**Problema**: Toda a lógica de checkout (criar customer, verificar subscription, criar session) está no controller.
+
+**Solução**: Mover para `Account` ou para uma Operation `Checkout::Create`:
+```ruby
+class Account
+  def create_stripe_checkout(lookup_key:)
+    # toda a lógica de checkout
+  end
+end
+```
+
+### 2.4 `SubscriptionController` — Stripe calls no controller
+
+**Problema**: `show`, `cancel`, `create_session` fazem chamadas diretas ao Stripe no controller.
+
+**Solução**: Mover para `Subscription` model ou Operations:
+```ruby
+class Subscription
+  def stripe_details
+    # fetch from Stripe
+  end
+
+  def cancel!(immediate: false, reason: nil)
+    # cancel logic
+  end
+end
+```
+
+### 2.5 `HabitsCheckController` — `update` com 20 linhas de delta manipulation
+
+**Problema**: O `update` do HabitsCheckController tem lógica complexa de merge/create/destroy de deltas inline.
+
+**Solução**: Extrair para o model `HabitCheck`:
+```ruby
+class HabitCheck
+  def sync_deltas(deltas_attributes)
+    # merge/create/destroy logic
+  end
+end
+```
+
+### 2.6 `HabitsCategoryController` — Sem tenant scoping no update/destroy
+
+**Problema**: `update` e `destroy` usam `HabitCategory.find(params[:id])` sem scoping por account. **Falha de segurança** — qualquer usuário pode editar/deletar categorias de outros.
+
+**Solução**: Sempre scoper por `@current_account`:
+```ruby
+def set_category
+  @category = HabitCategory.where(account_id: @current_account.id).find(params[:id])
+end
+```
+
+---
+
+## 3. Models — Lógica faltando, concerns subutilizados
+
+### 3.1 `Account` — Muito magro, deveria ser mais rico
+
+**Problema**: Account tem quase zero lógica de negócio. Toda a lógica de auth, checkout, subscription está nos controllers.
+
+**Solução**: Mover para Account:
+- `Account#generate_jwt`
+- `Account#authenticate_with_email`
+- `Account#ensure_provider(provider)`
+- `Account#subscription_active?`
+- `Account.find_or_create_from_google(payload)`
+- `Account.find_or_create_from_siwe(address)`
+
+### 3.2 `Subscription` — Sem métodos de domínio
+
+**Problema**: Status é verificado com string comparison inline nos controllers (`status != 'active'`). Sem predicates.
+
+**Solução**:
+```ruby
+class Subscription
+  def active?
+    status == 'active'
+  end
+
+  def trialing?
+    sub_status == 'trial'
+  end
+
+  def pending_cancellation?
+    sub_status == 'pending_cancellation'
+  end
+end
+```
+
+### 3.3 `Habit` — Business logic ok, falta scopes
+
+**Problema**: Não tem scopes de negócio. Queries ficam nos controllers (`where(:start_date.lte => end_date)`).
+
+**Solução**: Adicionar scopes:
+```ruby
+class Habit
+  scope :active, -> { where(finished_at: nil, paused_at: nil) }
+  scope :paused, -> { where(:paused_at.ne => nil) }
+  scope :finished, -> { where(:finished_at.ne => nil) }
+  scope :in_range, ->(start_date, end_date) {
+    where(:start_date.lte => end_date).any_of(
+      { :end_date.gte => start_date },
+      { :end_date => nil }
+    )
+  }
+  scope :ordered, -> { order_by(order: :asc) }
+  scope :preloaded, -> { includes(:habit_category) }
+end
+```
+
+### 3.4 `HabitCheck` — Lógica de validação muito complexa inline
+
+**Problema**: `and_validation` e `or_validation` fazem queries no validate, acopladas a `Time.current`. Difícil de testar.
+
+**Solução**: Extrair para concern `RuleEngineValidatable` ou methods mais limpos que aceitem a data como parâmetro.
+
+### 3.5 `Mongoid::Paranoia` — Soft deletes
+
+**Problema**: Habit, HabitCheck, HabitCheckDelta, HabitDelta, Mood, Subscription usam `Mongoid::Paranoia` (soft deletes). O compass diz "hard deletes + audit logs".
+
+**Decisão necessária**: Manter Paranoia (praticidade) ou migrar para hard deletes + audit logs (compass)?
+- Já existe `Auditable` concern — mas não está em todos os models
+- Paranoia adiciona complexidade (`deleted_at`, scoping automático)
+
+### 3.6 `ApplicationRecord` — Deveria ser removido
+
+**Problema**: `ApplicationRecord < ActiveRecord::Base` existe mas o projeto usa Mongoid, não ActiveRecord. Código morto.
+
+---
+
+## 4. Services — Avaliar necessidade
+
+### 4.1 `StripeService` — Wrapper fino sobre a gem
+
+**Problema**: `StripeService` é um wrapper 1:1 sobre a Stripe gem. Cada método apenas delega para `Stripe::*`. Segundo o compass, isso é abstração desnecessária.
+
+**Opções**:
+- **A**: Remover e chamar `Stripe::*` diretamente (compass puro)
+- **B**: Manter — isola Stripe da business logic, facilita mock em testes
+
+### 4.2 `EmailService` — Deveria ser model method ou job
+
+**Problema**: `EmailService` é chamado pelo `EmailJob`. Poderia ser um método no Account.
+
+**Solução**: Mover para `Account#send_welcome_email` ou manter como service (já que é integração externa).
+
+### 4.3 `RruleInternal` e `DateInternal` — Ok como POROs
+
+Estes são utilities legítimos, não service objects. Podem ficar em `app/services/` ou mover para `app/models/` (mais alinhado ao compass).
+
+---
+
+## 5. Operations & Contracts — Inconsistência
+
+**Problema**: Só `Habits::Create` usa Trailblazer Operation. Todos os outros CRUDs (HabitCheck, Mood, Category, etc.) fazem tudo inline no controller.
+
+**Decisão**:
+- **A**: Adotar Operations para TODOS os creates/updates complexos (consistência)
+- **B**: Remover Trailblazer, usar model methods (compass puro)
+- **C**: Manter Operations apenas para fluxos complexos (habits create), model methods para o resto
+
+---
+
+## 6. Background Jobs
+
+### 6.1 `EmailJob` — Sem error handling
+
+**Problema**: Nenhum `retry_on` ou `discard_on`. Se MailerSend falhar, o job vai pro dead queue sem contexto.
+
+**Solução**:
+```ruby
+class EmailJob < ApplicationJob
+  retry_on Faraday::TimeoutError, wait: :polynomially_longer, attempts: 3
+  discard_on ActiveJob::DeserializationError
+
+  def perform(account_id)
+    account = Account.find(account_id)
+    account.send_welcome_email  # lógica no model
+  end
+end
+```
+
+---
+
+## 7. Segurança
+
+### 7.1 `ActionController::Base` → `ActionController::API`
+
+**Problema**: Herda de `ActionController::Base` com `protect_from_forgery` e depois `skip_before_action :verify_authenticity_token`. É uma API — não precisa de CSRF.
+
+### 7.2 Tenant scoping falho no `HabitsCategoryController`
+
+**Arquivo**: `app/controllers/private/habits_category_controller.rb:19,26`
+
+`update` e `destroy` usam `HabitCategory.find(params[:id])` sem scoping. **Qualquer usuário autenticado pode editar/deletar categorias de outros accounts.**
+
+### 7.3 `rescue Exception => e` no `AuthController#siwe_verify`
+
+**Problema**: Captura `Exception` (inclui `SystemExit`, `NoMemoryError`). Deveria ser `StandardError`.
+
+### 7.4 JWT sem expiração
+
+**Problema**: `JWT.encode({ account_id: account.id }, ...)` sem `exp` claim. Tokens nunca expiram.
+
+**Solução**: Adicionar `exp: 24.hours.from_now.to_i` ao payload.
+
+### 7.5 `WEBHOOK_SECRET` como constante global
+
+**Problema**: `WEBHOOK_SECRET = ENV['STRIPE_WEBHOOK_SECRET']` está no nível do arquivo, fora da classe. Deveria ser lido dentro do método.
+
+---
+
+## 8. Observabilidade
+
+### 8.1 `puts` no lugar de logging
+
+**Problema**: `EmailService` usa `puts` para erros. Deveria usar `Rails.logger.error`.
+
+### 8.2 Sem structured logging
+
+**Problema**: Não há structured logging. Logs são strings soltas.
+
+---
+
+## 9. Testing Gaps
+
+### 9.1 Sem testes para:
+- `StripeWebhookController`
+- `CheckoutController`
+- `SubscriptionController`
+- `AuthController#google_auth`
+- `AuthController#siwe_verify`
+- `Auditable` concern
+- `RruleInternal`
+
+(Verificar cobertura real nos specs existentes)
+
+---
+
+## 10. Ordem de Execução Sugerida
+
+### Fase 1 — Segurança (urgente)
+1. Fix tenant scoping no `HabitsCategoryController`
+2. Adicionar JWT expiration
+3. `rescue Exception` → `rescue StandardError`
+4. `WEBHOOK_SECRET` → dentro do método
+
+### Fase 2 — Foundation
+5. `ActionController::Base` → `ActionController::API`
+6. Mover auth logic do `ApplicationController` para `ActiveAndAuthorized`
+7. Remover `ApplicationRecord` (código morto)
+8. Enriquecer models: `Account#generate_jwt`, `Subscription#active?`, `Habit` scopes
+
+### Fase 3 — Controllers
+9. Extrair methods do `AuthController` para `Account` model (manter 1 controller)
+10. Extrair checkout/subscription logic para models (chamar `Stripe::*` direto)
+11. Remover `StripeService` — chamar Stripe gem diretamente
+12. Extrair delta manipulation do `HabitsCheckController` para model
+13. Fix error handling no `EmailJob`
+
+### Fase 4 — Operations → Model Methods
+14. Mover `Habits::Create` operation para `Account#create_habit` ou `Habit` class method
+15. Remover Trailblazer + Dry-Validation, usar validações no model
+16. Remover `app/operations/` e `app/contracts/`
+
+### Fase 5 — Routing
+17. Reescrever `routes.rb` com `resources` e `namespace`
+18. Remover rotas duplicadas
+
+### Fase 6 — Cleanup
+19. `puts` → `Rails.logger`
+20. Structured logging
+
+### Fase 7 — Testes
+21. Testes para controllers sem cobertura
+22. Testes de segurança (tenant isolation)
+
+---
+
+## Decisões Tomadas
+
+| # | Decisão | Resultado |
+|---|---------|-----------|
+| 1 | Soft deletes (Paranoia) vs Hard deletes | **Manter Paranoia** — já está em 6 models, funciona |
+| 2 | StripeService | **Remover** — chamar `Stripe::*` direto, sem wrapper |
+| 3 | Trailblazer Operations | **Remover** — mover lógica para model methods |
+| 4 | AuthController | **Manter 1 controller** — extrair methods para `Account` model |

--- a/docs/compass/authentication.md
+++ b/docs/compass/authentication.md
@@ -1,0 +1,71 @@
+# Authentication
+
+> Own your auth. Separate identity from membership. Keep it simple.
+
+## Why Not Devise
+
+- Custom auth is easier to understand, debug, and modify
+- You own every line — no black-box middleware
+- Devise is overkill for API-only backends
+
+## Identity vs Account Separation
+
+Identity = the person (auth credentials). Account = membership + subscription.
+
+One person can have multiple auth methods (email/password, Web3 wallet) while belonging to the same account. This separation keeps auth concerns out of business logic.
+
+```ruby
+# Auth credentials live on Account (or a separate Identity model)
+# Business data (habits, subscriptions) also live on Account
+# The JWT concern only cares about finding the account — not how they signed up
+```
+
+## Declarative Auth DSL
+
+Controllers declare auth requirements at class level:
+
+```ruby
+# Private controllers — require JWT + active subscription
+class Api::V1::Private::HabitsController < ApplicationController
+  include ActiveAndAuthorized  # before_action :authorize_request + :check_subscription
+end
+
+# Public controllers — no auth required
+class Api::V1::Public::AuthController < ApplicationController
+  # No auth concern included
+end
+```
+
+The pattern: a concern that sets `@current_account` from the JWT, then a subscription check that returns 402 if inactive.
+
+## Token-Based Auth for APIs
+
+APIs use stateless JWT tokens, not cookies/sessions:
+
+```ruby
+# Encode
+JWT.encode({ account_id: account.id, exp: 24.hours.from_now.to_i }, jwt_secret)
+
+# Decode + find account
+decoded = JWT.decode(token, jwt_secret)
+@current_account = Account.find(decoded["account_id"])
+```
+
+No session state on the server. No cookies. Every request carries its own auth.
+
+## Rate Limiting Auth Endpoints
+
+```ruby
+rate_limit to: 10, within: 3.minutes, only: :create, with: -> {
+  render json: { error: "Try again later" }, status: :too_many_requests
+}
+```
+
+## Key Principles
+
+1. **Own your auth code** — a concern + JWT encode/decode is all you need
+2. **Separate identity from membership** — auth method != business entity
+3. **Stateless tokens for APIs** — JWT, no server-side sessions
+4. **Declarative auth DSL** — `include ActiveAndAuthorized` reads like a spec
+5. **Rate limit auth endpoints** — built-in Rails `rate_limit`
+6. **402 for subscription checks** — separate auth (401) from payment (402)

--- a/docs/compass/background-jobs.md
+++ b/docs/compass/background-jobs.md
@@ -1,0 +1,96 @@
+# Background Jobs
+
+> Shallow jobs. Error handling patterns. Sidekiq conventions.
+
+## Shallow Jobs
+
+Jobs are thin — delegate to models:
+
+```ruby
+class EmailJob < ApplicationJob
+  def perform(account, template)
+    account.send_email(template)
+  end
+end
+```
+
+## Error Handling
+
+### Transient — retry with backoff
+
+```ruby
+retry_on Net::OpenTimeout, Net::ReadTimeout, wait: :polynomially_longer, attempts: 5
+retry_on Faraday::TimeoutError, wait: :polynomially_longer
+```
+
+### Permanent — swallow, log
+
+```ruby
+discard_on ActiveJob::DeserializationError
+
+rescue_from MailerSend::ApiError do |error|
+  if error.status == 422  # invalid email, permanent failure
+    Rails.logger.warn("Permanent email failure: #{error.message}")
+  else
+    raise  # re-raise for retry
+  end
+end
+```
+
+## `_later` / `_now` Convention
+
+```ruby
+class Account
+  def send_welcome_email         # sync — actual work
+    MailerSendService.deliver(self, :welcome)
+  end
+
+  private
+
+  def send_welcome_email_later   # async — enqueue
+    EmailJob.perform_later(self, :welcome)
+  end
+end
+```
+
+## Sidekiq Queues
+
+Organize by priority:
+
+```ruby
+class EmailJob < ApplicationJob
+  queue_as :default
+end
+
+class WebhookDeliveryJob < ApplicationJob
+  queue_as :webhooks
+end
+```
+
+## Idempotency
+
+Jobs may run more than once. Design for it:
+
+```ruby
+def perform(habit_check_id)
+  check = HabitCheck.find(habit_check_id)
+  return if check.notification_sent?  # idempotency guard
+
+  check.send_notification!
+end
+```
+
+## Maintenance Jobs
+
+- Clean expired tokens periodically
+- Clean orphaned data: old audit logs, stale records
+- Clean finished Sidekiq jobs via `Sidekiq::DeadSet`
+
+## Key Principles
+
+1. Jobs are thin wrappers — logic lives in models
+2. Retry transient errors, discard permanent ones
+3. Use `_later`/`_now` naming convention
+4. Design for idempotency — jobs may run more than once
+5. Organize queues by priority
+6. Periodic cleanup of expired/orphaned data

--- a/docs/compass/controllers.md
+++ b/docs/compass/controllers.md
@@ -1,0 +1,164 @@
+# Controllers
+
+> Thin controllers, rich models, composable concerns. API-focused.
+
+## Core: Thin Controllers, Rich Models
+
+```ruby
+# GOOD: Controller just orchestrates
+class Cards::ClosuresController < ApplicationController
+  include CardScoped
+
+  def create
+    @card.close
+    head :no_content
+  end
+
+  def destroy
+    @card.reopen
+    head :no_content
+  end
+end
+```
+
+```ruby
+# BAD: Business logic in controller
+class Cards::ClosuresController < ApplicationController
+  def create
+    @card.transaction do
+      @card.create_closure!(user: Current.user)
+      @card.events.create!(action: :closed, creator: Current.user)
+      @card.watchers.each { |w| NotificationJob.perform_later(w, @card) }
+    end
+  end
+end
+```
+
+## Authorization: Controller Checks, Model Defines
+
+```ruby
+# Controller checks permission
+class CardsController < ApplicationController
+  before_action :ensure_permission_to_administer_card, only: [:destroy]
+
+  private
+    def ensure_permission_to_administer_card
+      head :forbidden unless Current.user.can_administer_card?(@card)
+    end
+end
+
+# Model defines what permission means
+class User < ApplicationRecord
+  def can_administer_card?(card)
+    admin? || card.creator == self
+  end
+end
+```
+
+## Resource Scoping Concerns
+
+```ruby
+module CardScoped
+  extend ActiveSupport::Concern
+  included do
+    before_action :set_card
+  end
+  private
+    def set_card
+      @card = Current.user.accessible_cards.find_by!(number: params[:card_id])
+    end
+end
+```
+
+Multiple controllers reuse the same concern:
+
+```ruby
+class Cards::ClosuresController < ApplicationController
+  include CardScoped
+end
+
+class Cards::WatchesController < ApplicationController
+  include CardScoped
+end
+
+class Cards::PinsController < ApplicationController
+  include CardScoped
+end
+```
+
+## Request Context Concern
+
+```ruby
+module CurrentRequest
+  extend ActiveSupport::Concern
+  included do
+    before_action do
+      Current.http_method = request.method
+      Current.request_id  = request.uuid
+      Current.user_agent  = request.user_agent
+      Current.ip_address  = request.ip
+    end
+  end
+end
+```
+
+## Filtering Concern
+
+```ruby
+module FilterScoped
+  extend ActiveSupport::Concern
+  included do
+    before_action :set_filter
+  end
+  private
+    def set_filter
+      @filter = Current.user.filters.from_params(filter_params)
+    end
+    def filter_params
+      params.permit(*Filter::PERMITTED_PARAMS)
+    end
+end
+```
+
+The Filter model does the heavy lifting:
+
+```ruby
+class Filter < ApplicationRecord
+  def cards
+    result = creator.accessible_cards.preloaded
+    result = result.where(board: boards.ids) if boards.present?
+    result = result.tagged_with(tags.ids) if tags.present?
+    result = result.assigned_to(assignees.ids) if assignees.present?
+    result.distinct
+  end
+end
+```
+
+## API Response Patterns
+
+```ruby
+# Prefer head :no_content for updates/deletes
+def update
+  @card.update!(card_params)
+  head :no_content
+end
+
+# 201 + Location for creates
+def create
+  @card = current_account.cards.create!(card_params)
+  render json: @card, status: :created, location: @card
+end
+```
+
+| Action | Success Code |
+|--------|--------------|
+| Create | `201 Created` + `Location` header |
+| Update | `204 No Content` |
+| Delete | `204 No Content` |
+
+## Concern Composition Rules
+
+1. Concerns can include other concerns
+2. Use `before_action` in `included` block
+3. Provide shared private methods
+4. Add to `etag` for HTTP caching

--- a/docs/compass/database.md
+++ b/docs/compass/database.md
@@ -1,0 +1,122 @@
+# Database Patterns
+
+> State as records, schemaless documents, indexing strategy. Adapted for MongoDB/Mongoid.
+
+## State as Records — Not Booleans
+
+See [models.md](models.md) for full pattern. Key idea: an embedded or associated document with `user` and `created_at` beats a `closed: true` boolean.
+
+## No Soft Deletes
+
+Hard delete records. Use events/audit logs for history (see `Auditable` concern).
+
+## Schemaless Doesn't Mean Structureless
+
+MongoDB has no migrations, but models should still define their fields explicitly in Mongoid:
+
+```ruby
+class Habit
+  include Mongoid::Document
+
+  field :title, type: String
+  field :rrule, type: String
+  field :rule_engine_enabled, type: Boolean, default: false
+
+  embeds_many :habit_deltas
+  belongs_to :account
+end
+```
+
+Explicit fields = self-documenting schema.
+
+## Index What You Query
+
+```ruby
+class Habit
+  include Mongoid::Document
+
+  index({ account_id: 1 })
+  index({ account_id: 1, created_at: -1 })
+
+  # Unique constraints via index
+  index({ code: 1 }, { unique: true })
+end
+```
+
+Create indexes: `rake db:mongoid:create_indexes`
+
+## Unique Constraints via Indexes
+
+```ruby
+# Application-level validation (race conditions possible)
+validates :code, uniqueness: true
+
+# Preferred — database constraint
+index({ code: 1 }, { unique: true })
+```
+
+Use both when you need user-facing error messages. Use index-only for internal data.
+
+## Account Scoping (Multi-Tenancy)
+
+```ruby
+validates :number, uniqueness: { scope: :account_id }
+```
+
+## Always Scope Lookups
+
+```ruby
+# Bad
+@habit = Habit.find(params[:id])
+
+# Good
+@habit = @current_account.habits.find(params[:id])
+```
+
+## Embedded Documents for Tight Coupling
+
+MongoDB's strength — use embedded documents for data that always lives with its parent:
+
+```ruby
+class Habit
+  embeds_many :habit_deltas
+end
+
+class HabitDelta
+  embedded_in :habit
+end
+```
+
+Use `has_many`/`belongs_to` for data queried independently.
+
+## Batch Operations Over Loops
+
+```ruby
+# Good
+Habit.where(account_id: account.id, archived: true).delete_all
+
+# Bad — N+1 delete
+account.habits.archived.each(&:destroy)
+```
+
+## Pre-Computed Counts
+
+Without ActiveRecord's `counter_cache`, maintain counts manually:
+
+```ruby
+after_create :increment_parent_count
+after_destroy :decrement_parent_count
+
+# Or use MongoDB's $inc atomically
+account.inc(habits_count: 1)
+```
+
+## Key Principles
+
+1. State records over booleans
+2. Hard deletes + audit logs
+3. Explicit field definitions (self-documenting schema)
+4. Index what you query — `rake db:mongoid:create_indexes`
+5. Unique indexes for DB-level constraints
+6. Embedded documents for tightly coupled data
+7. Always scope through tenant/account

--- a/docs/compass/filtering.md
+++ b/docs/compass/filtering.md
@@ -1,0 +1,127 @@
+# Filtering
+
+> Filter POROs, composable scopes, URL-based state.
+
+## The Problem
+
+Controllers doing too much — mixing query logic with HTTP concerns:
+
+```ruby
+# BAD: controller doing filtering
+def index
+  @cards = current_account.cards
+  @cards = @cards.where(status: params[:status]) if params[:status].present?
+  @cards = @cards.where(assignee_id: params[:assignee]) if params[:assignee].present?
+  @cards = @cards.tagged_with(params[:tag]) if params[:tag].present?
+  @cards = @cards.page(params[:page])
+end
+```
+
+## The Solution: Filter PORO
+
+```ruby
+class Bucket::BubbleFilter
+  attr_reader :bucket, :user, :params
+
+  def initialize(bucket:, user:, params: {})
+    @bucket = bucket
+    @user = user
+    @params = params.to_h.symbolize_keys
+  end
+
+  def cards
+    @cards ||= begin
+      scope = bucket.cards.visible_to(user)
+      scope = apply_status_filter(scope)
+      scope = apply_assignee_filter(scope)
+      scope = apply_tag_filter(scope)
+      scope = apply_search(scope)
+      scope = apply_sort(scope)
+      scope
+    end
+  end
+
+  def any_active?
+    params.except(:sort).values.any?(&:present?)
+  end
+
+  private
+
+  def apply_status_filter(scope)
+    return scope unless params[:status].present?
+    scope.where(status: params[:status])
+  end
+
+  def apply_assignee_filter(scope)
+    return scope unless params[:assignee].present?
+    params[:assignee] == "none" ? scope.unassigned : scope.where(assignee_id: params[:assignee])
+  end
+
+  def apply_tag_filter(scope)
+    return scope unless params[:tag].present?
+    scope.tagged_with(params[:tag])
+  end
+
+  def apply_search(scope)
+    return scope unless params[:query].present?
+    scope.search(params[:query])
+  end
+
+  def apply_sort(scope)
+    case params[:sort]
+    when "newest"  then scope.order(created_at: :desc)
+    when "oldest"  then scope.order(created_at: :asc)
+    when "updated" then scope.order(updated_at: :desc)
+    else scope.order(position: :asc)
+    end
+  end
+end
+```
+
+Controller becomes trivial:
+
+```ruby
+def index
+  filter = Bucket::BubbleFilter.new(
+    bucket: current_account, user: current_user, params: filter_params
+  )
+  @cards = filter.cards.page(params[:page])
+  render json: @cards
+end
+```
+
+## Key Pattern: Each filter returns scope unchanged if param is blank
+
+This enables clean chaining without conditionals in the caller.
+
+## URL-Based State
+
+Filters encoded as query parameters are bookmarkable, shareable, and work with back/forward:
+
+```
+GET /api/v1/habits?status=active&tag=health&sort=newest
+```
+
+## Filter Params Module
+
+```ruby
+module Filter::Params
+  PERMITTED_PARAMS = %i[status assignee tag query sort].freeze
+
+  def as_params
+    params.slice(*PERMITTED_PARAMS).compact_blank
+  end
+
+  def as_params_without(*keys)
+    as_params.except(*keys)
+  end
+end
+```
+
+## Key Principles
+
+1. **Extract filter logic into POROs** — controllers delegate to filter objects
+2. **Compose scopes lazily** — each method returns scope unchanged if inactive
+3. **URL state for filters** — query parameters, not session/cookies
+4. **Memoize the result** — `@cards ||= begin...end`
+5. **Always scope through user** — `bucket.cards.visible_to(user)`

--- a/docs/compass/index.md
+++ b/docs/compass/index.md
@@ -1,0 +1,53 @@
+# 37signals Rails Compass (API Edition)
+
+> Transferable Rails patterns from 37signals, adapted for API-only Rails + MongoDB/Mongoid.
+> Source: [unofficial-37signals-coding-style-guide](https://github.com/pedrotroccoli/unofficial-37signals-coding-style-guide)
+
+## Quick Start — The 37signals Way
+
+1. **Rich domain models** over service objects (with Trailblazer for orchestration)
+2. **CRUD controllers** over custom actions
+3. **Concerns** for horizontal code sharing
+4. **Records as state** over boolean fields
+5. **Build it yourself** before reaching for gems
+6. **Ship to learn** — prototype quality is valid
+7. **Vanilla Rails is plenty** — maximize what Rails gives you
+
+## Guides
+
+### Philosophy & Principles
+- [philosophy.md](philosophy.md) — Ship/Validate/Refine, naming, narrow APIs, review culture
+- [what-they-avoid.md](what-they-avoid.md) — No Pundit, no Devise, minimal service objects (Trailblazer exception)
+
+### Core Rails
+- [models.md](models.md) — Concerns, state records, POROs, scopes (Mongoid)
+- [controllers.md](controllers.md) — Thin controllers, concern catalog, API response patterns
+- [routing.md](routing.md) — Everything is CRUD, noun-based resources, shallow nesting
+
+### Backend
+- [authentication.md](authentication.md) — JWT + SIWE, own your auth, declarative DSL
+- [multi-tenancy.md](multi-tenancy.md) — Account-scoped everything, 404 over 403, subscription gating
+- [database.md](database.md) — Mongoid patterns, indexing, embedded docs, atomic operations
+- [background-jobs.md](background-jobs.md) — Sidekiq, error handling, shallow jobs, idempotency
+- [filtering.md](filtering.md) — Filter POROs, composable scopes, URL state
+- [performance.md](performance.md) — N+1, ETags, field projection, cursor pagination
+
+### Infrastructure
+- [security.md](security.md) — SSRF, rate limiting, authorization, CORS, HMAC signatures
+- [webhooks.md](webhooks.md) — SSRF protection, delinquency tracking, HMAC, state machine
+- [testing.md](testing.md) — Behavior testing, VCR, integration tests
+- [observability.md](observability.md) — Structured logging, metrics, console auditing
+
+## Adapted for This Project
+
+This compass adapts 37signals patterns for:
+- **MongoDB/Mongoid** instead of PostgreSQL/ActiveRecord
+- **JWT + SIWE** instead of cookie-based sessions
+- **Sidekiq** instead of Solid Queue
+- **Trailblazer Operations** for multi-step orchestration
+- **Dry-Validation Contracts** for input validation
+
+## Removed (not relevant for API-only)
+
+Stimulus, CSS, Hotwire, Views, Accessibility, Mobile, ActionCable,
+Action Text, Active Storage, design/UX patterns (Jason Zimdars).

--- a/docs/compass/models.md
+++ b/docs/compass/models.md
@@ -1,0 +1,159 @@
+# Models
+
+> Rich domain models with composable concerns and state as records. Adapted for Mongoid.
+
+## Heavy Use of Concerns
+
+```ruby
+class Habit
+  include Mongoid::Document
+  include Mongoid::Timestamps
+  include Auditable, RuleEngineEnabled
+end
+```
+
+## Concern Structure: Self-Contained
+
+```ruby
+module Auditable
+  extend ActiveSupport::Concern
+
+  included do
+    after_create  :log_create
+    after_update  :log_update
+    after_destroy :log_destroy
+  end
+
+  private
+
+  def log_create
+    AuditLog.create!(auditable: self, action: :create, account: account)
+  end
+  # ...
+end
+```
+
+## State as Records, Not Booleans
+
+```ruby
+# BAD
+class Habit
+  field :closed, type: Boolean
+  scope :closed, -> { where(closed: true) }
+end
+
+# GOOD — who/when, plus audit trail
+class Closure
+  include Mongoid::Document
+  belongs_to :habit
+  belongs_to :user, optional: true
+  field :created_at, type: Time
+end
+
+class Habit
+  has_one :closure, dependent: :destroy
+  scope :closed, -> { where(:closure.exists => true) }
+  scope :open, -> { where(:closure.exists => false) }
+end
+```
+
+## Default Values
+
+```ruby
+field :rule_engine_enabled, type: Boolean, default: false
+field :status, type: String, default: "active"
+
+belongs_to :creator, class_name: "Account", default: -> { Current.account }
+```
+
+## Current for Request Context
+
+```ruby
+class Current < ActiveSupport::CurrentAttributes
+  attribute :account, :request_id, :user_agent, :ip_address
+end
+```
+
+## Minimal Validations
+
+Validate only what the database can't enforce. Contextual validations when needed:
+
+```ruby
+validates :title, presence: true
+validates :rrule, presence: true, on: :create
+```
+
+For complex validation, use Dry-Validation contracts (project convention):
+
+```ruby
+class Habits::CreateHabitContract < Dry::Validation::Contract
+  params do
+    required(:title).filled(:string)
+    required(:rrule).filled(:string)
+  end
+end
+```
+
+## Let It Crash (Bang Methods)
+
+```ruby
+@habit = @current_account.habits.create!(habit_params)
+```
+
+## Callbacks: Used Sparingly
+
+For setup/cleanup only, NOT business logic.
+
+## PORO Patterns
+
+POROs are model-adjacent, NOT service objects (controller-adjacent):
+
+```ruby
+# Presentation/serialization logic
+class Habit::Summary
+  def initialize(habit)
+    @habit = habit
+  end
+
+  def as_json
+    { title: @habit.title, streak: calculate_streak }
+  end
+end
+```
+
+## Scope Naming
+
+```ruby
+# Good — business-focused
+scope :active, -> { where(status: "active") }
+scope :for_account, ->(account) { where(account_id: account.id) }
+scope :recently_created, -> { order(created_at: :desc) }
+scope :with_rule_engine, -> { where(rule_engine_enabled: true) }
+
+# Bad — implementation-ish
+scope :where_not_archived, -> { ... }
+```
+
+## Concern Organization
+
+1. Each concern: **50-150 lines**
+2. Must be **cohesive** — related functionality together
+3. Don't create concerns just to reduce file size
+4. Name for capability: `Auditable`, `RuleEngineEnabled`
+5. Concerns = auxiliary **public** traits. Private methods = inline in main class.
+
+## Embedded Documents for Value Objects
+
+```ruby
+class Habit
+  embeds_many :habit_deltas
+end
+
+class HabitDelta
+  embedded_in :habit
+  field :value, type: Float
+  field :recorded_at, type: Time
+end
+```
+
+Embedded docs are atomically saved with their parent — no separate queries.

--- a/docs/compass/multi-tenancy.md
+++ b/docs/compass/multi-tenancy.md
@@ -1,0 +1,98 @@
+# Multi-Tenancy
+
+> Account-scoped everything. Secure by default.
+
+## Core Principle
+
+Every query goes through `@current_account`. No exceptions.
+
+```ruby
+# Private controllers set @current_account via JWT
+module ActiveAndAuthorized
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authorize_request
+    before_action :check_subscription
+  end
+
+  private
+
+  def authorize_request
+    token = request.headers["Authorization"]&.split(" ")&.last
+    decoded = JWT.decode(token, jwt_secret)
+    @current_account = Account.find(decoded["account_id"])
+  rescue JWT::DecodeError, Mongoid::Errors::DocumentNotFound
+    render json: { error: "Unauthorized" }, status: :unauthorized
+  end
+end
+```
+
+## Scope All Data Access
+
+```ruby
+# Bad — bypasses tenant isolation
+@habit = Habit.find(params[:id])
+
+# Good — scoped to current account
+@habit = @current_account.habits.find(params[:id])
+```
+
+This prevents one account from accessing another's data, even with a valid ID.
+
+## Account as Root Aggregate
+
+```ruby
+class Account
+  include Mongoid::Document
+
+  has_many :habits, dependent: :destroy
+  has_many :habit_checks, dependent: :destroy
+  has_many :moods, dependent: :destroy
+  has_one :subscription
+end
+```
+
+All business data hangs off Account. This makes data isolation natural.
+
+## 404 Over 403
+
+When a user tries to access another account's resource, return **404 Not Found** — not 403 Forbidden. Don't leak existence.
+
+```ruby
+# .find on a scoped query raises Mongoid::Errors::DocumentNotFound
+# which should map to 404
+@habit = @current_account.habits.find(params[:id])
+```
+
+## Subscription Gating
+
+Separate auth (401) from payment (402):
+
+```ruby
+def check_subscription
+  unless @current_account.subscription_active?
+    render json: { error: "Subscription required" }, status: :payment_required
+  end
+end
+```
+
+## Background Jobs: Preserve Tenant Context
+
+Jobs run outside the request cycle — pass the account explicitly:
+
+```ruby
+# Bad — Current.account won't exist in job context
+EmailJob.perform_later(template: :welcome)
+
+# Good — pass account explicitly
+EmailJob.perform_later(@current_account.id, template: :welcome)
+```
+
+## Key Principles
+
+1. **Every query scoped through `@current_account`** — no global lookups
+2. **Account as root aggregate** — all data belongs to an account
+3. **404 not 403** for cross-tenant access — don't leak existence
+4. **Separate 401/402** — auth vs subscription are different concerns
+5. **Pass account to jobs** — no implicit tenant in async context

--- a/docs/compass/observability.md
+++ b/docs/compass/observability.md
@@ -1,0 +1,44 @@
+# Observability
+
+> Structured logging, metrics, console auditing.
+
+## Structured JSON Logging
+
+```ruby
+config.log_level = :fatal  # suppress unstructured
+config.structured_logging.logger = ActiveSupport::Logger.new(STDOUT)
+```
+
+## Multi-Tenant Context in Logs
+
+```ruby
+before_action { logger.struct tenant: Current.account&.id }
+```
+
+## User Context in Logs
+
+```ruby
+logger.struct "Authorized User##{session.user.id}",
+  authentication: { user: { id: session.user.id } }
+```
+
+## Silence Health Checks
+
+```ruby
+config.silence_healthcheck_path = "/up"
+```
+
+## Console Auditing (Production)
+
+```ruby
+gem "console1984"
+gem "audits1984"
+config.console1984.protected_environments = %i[production staging]
+```
+
+## Key Principles
+
+1. Structured JSON logs — queryable, parseable
+2. Include tenant/user context in every log entry
+3. Silence noise (health checks)
+4. Audit console access in production

--- a/docs/compass/performance.md
+++ b/docs/compass/performance.md
@@ -1,0 +1,101 @@
+# Performance
+
+> N+1 prevention, caching, query optimization. Adapted for Mongoid.
+
+## N+1 Prevention
+
+```ruby
+# Bad — extra query per item
+habits.each { |h| h.account.name }
+
+# Good — eager load
+Habit.includes(:account).where(status: "active")
+```
+
+## Preloaded Scopes
+
+```ruby
+scope :preloaded, -> { includes(:account, :habit_checks) }
+```
+
+Define and use consistently to avoid ad-hoc `includes`.
+
+## HTTP Caching (ETags)
+
+```ruby
+def show
+  @habit = @current_account.habits.find(params[:id])
+  fresh_when etag: [@habit, @current_account]
+end
+```
+
+Server still runs the action but skips rendering if ETag matches. Works great for read-heavy APIs.
+
+## Batch Operations Over Loops
+
+```ruby
+# Good — single query
+Habit.where(account_id: account.id, archived: true).delete_all
+
+# Bad — N+1 delete
+account.habits.archived.each(&:destroy)
+```
+
+## Use `pluck` Over `map`
+
+```ruby
+# Good — returns raw values, no model instantiation
+Habit.where(account: account).pluck(:title)
+
+# Bad — instantiates full Mongoid documents
+account.habits.map(&:title)
+```
+
+## Use `update_all` for Bulk Updates
+
+When no callbacks needed:
+
+```ruby
+Habit.where(account_id: old_id).update_all(account_id: new_id)
+```
+
+## Memoize Hot Paths
+
+```ruby
+def active_habits
+  @active_habits ||= habits.where(status: "active").to_a
+end
+```
+
+## Pre-Computed Counts
+
+Without ActiveRecord's `counter_cache`, use MongoDB's atomic `$inc`:
+
+```ruby
+# Atomic increment — no read-modify-write race
+account.inc(habits_count: 1)
+account.inc(habits_count: -1)
+```
+
+## MongoDB-Specific Optimizations
+
+- **Projection**: Only fetch fields you need — `Habit.where(...).only(:title, :rrule)`
+- **Covered queries**: If all queried/returned fields are in an index, MongoDB never touches the document
+- **Embedded docs over joins**: No `JOIN` cost — embedded data loads with the parent
+
+## Pagination
+
+- 25-50 items per page
+- Cursor-based pagination (use `_id` or `created_at`) over offset-based
+- Never load unbounded collections
+
+## Key Principles
+
+1. Define `preloaded` scopes, use them everywhere
+2. In-memory checks over extra queries
+3. HTTP caching with ETags for read endpoints
+4. Batch operations over loops
+5. `pluck` over `map`, `update_all` over `each.update`
+6. `only` for field projection in Mongoid
+7. Atomic `$inc` for counters
+8. Always paginate — cursor-based preferred

--- a/docs/compass/philosophy.md
+++ b/docs/compass/philosophy.md
@@ -1,0 +1,90 @@
+# Philosophy & Principles
+
+> Core principles from 37signals' 265 PRs. Adapted for API-only Rails.
+
+## Ship, Validate, Refine
+
+- Merge "prototype quality" code to validate with real usage before cleanup
+- Don't polish prematurely — real-world usage reveals what matters
+- Features evolve through iterations
+
+## Fix Root Causes, Not Symptoms
+
+**Bad**: Add retry logic for race conditions
+**Good**: Use `enqueue_after_transaction_commit` to prevent the race
+
+## Vanilla Rails Over Abstractions
+
+- Thin controllers calling rich domain models
+- No service objects unless truly justified
+- Direct model calls: `@card.comments.create!(params)`
+- When services exist, they're POROs: `Signup.new(email:).create_identity`
+
+## When to Extract
+
+- Start in controller, extract when it gets messy
+- Don't extract prematurely — wait for pain
+- Rule of three: duplicate twice before abstracting
+
+## Write-Time vs Read-Time
+
+All manipulation should happen when you save, not when you present:
+- Pre-compute roll-ups at write time
+- Use counter caches instead of manual counting
+- Use `dependent: :delete_all` when no callbacks needed
+
+## Abstractions Must Earn Their Keep
+
+- Question every layer of indirection
+- If you can't point to 3+ variations that need it, inline it
+- Methods and classes that don't explain anything should be removed
+
+## Naming Principles
+
+- **Positive names**: `active` not `not_deleted`
+- **Domain language**: `depleted?` not `over_limit?`
+- **Method names reflect return value**: `collect` implies array
+- Consistent domain language throughout
+
+## Be Explicit Over Clever
+
+- 2-3 cases: explicit `case` statements beat metaprogramming
+- Don't add base class extensions for one-off methods
+- Define methods directly vs introspection
+
+## Narrow Public APIs
+
+- Only expose what's actually used
+- "The narrower the public surface of a class the better"
+
+## Objects Emerge from Coupling
+
+When parameters get passed through multiple method layers, extract an object:
+
+```ruby
+# Smell: shared param coupling
+def cost(within:); end
+def limit_cost(within:); end
+
+# Solution: extract a model
+class Ai::Quota < ApplicationRecord
+  def spend(cost); end
+  def ensure_not_depleted; end
+end
+```
+
+## StringInquirer for Action Predicates
+
+```ruby
+def action
+  self[:action].inquiry
+end
+# Usage: event.action.completed?
+```
+
+## Review Culture
+
+- **Teach through questions**: "What do you think of..." not "Change this to..."
+- **Name technical debt specifically**: unnamed debt is invisible debt
+- **Label quality level explicitly**: "prototype quality" sets expectations
+- **Ship to validate**: production data answers faster than local profiling

--- a/docs/compass/routing.md
+++ b/docs/compass/routing.md
@@ -1,0 +1,99 @@
+# Routing
+
+> Everything is CRUD. Resource-based routing over custom actions.
+
+## The CRUD Principle
+
+Every action maps to a CRUD verb. When something doesn't fit, **create a new resource**.
+
+```ruby
+# BAD: Custom actions on existing resource
+resources :cards do
+  post :close
+  post :reopen
+  post :archive
+end
+
+# GOOD: New resources for each state change
+resources :cards do
+  resource :closure      # POST to close, DELETE to reopen
+  resource :goldness     # POST to gild, DELETE to ungild
+  resource :pin          # POST to pin, DELETE to unpin
+  resource :watch        # POST to watch, DELETE to unwatch
+end
+```
+
+## Noun-Based Resources
+
+Turn verbs into nouns:
+
+| Action | Resource |
+|--------|----------|
+| Close a card | `card.closure` |
+| Watch a board | `board.watching` |
+| Pin an item | `item.pin` |
+| Publish a board | `board.publication` |
+| Assign a user | `card.assignment` |
+
+## Module Scoping
+
+```ruby
+# scope module (no URL prefix)
+resources :cards do
+  scope module: :cards do
+    resource :closure      # Cards::ClosuresController at /cards/:id/closure
+    resources :assignments
+    resources :comments
+  end
+end
+```
+
+## Shallow Nesting
+
+```ruby
+resources :boards, shallow: true do
+  resources :cards
+end
+# /boards/:board_id/cards      (index, new, create)
+# /cards/:id                   (show, edit, update, destroy)
+```
+
+## Singular Resources
+
+Use `resource` (singular) for one-per-parent:
+
+```ruby
+resources :cards do
+  resource :closure
+  resource :watching
+end
+```
+
+## API Namespace
+
+```ruby
+namespace :api do
+  namespace :v1 do
+    namespace :private do
+      resources :habits
+      resources :habits_check
+    end
+    namespace :public do
+      resources :auth, only: [] do
+        collection do
+          post :sign_in
+          post :sign_up
+        end
+      end
+    end
+  end
+end
+```
+
+## Key Principles
+
+1. **Every action is CRUD** — create, read, update, or destroy something
+2. **Verbs become nouns** — "close" becomes "closure" resource
+3. **Shallow nesting** — avoid deep URL nesting
+4. **Singular when appropriate** — `resource` for one-per-parent
+5. **Same controller, different format** — no separate API controllers when possible

--- a/docs/compass/security.md
+++ b/docs/compass/security.md
@@ -1,0 +1,92 @@
+# Security
+
+> SSRF protection, rate limiting, authorization, API-specific concerns.
+
+## SSRF Protection (for Webhooks/External Calls)
+
+- DNS pinning: resolve once, use pinned IP
+- Block private networks (127.0.0.0/8, 10.0.0.0/8, 169.254.0.0/16, 172.16.0.0/12, 192.168.0.0/16)
+- Validate at creation AND request time
+
+```ruby
+DISALLOWED_IP_RANGES = [
+  IPAddr.new("127.0.0.0/8"),
+  IPAddr.new("10.0.0.0/8"),
+  IPAddr.new("169.254.0.0/16"),
+  IPAddr.new("172.16.0.0/12"),
+  IPAddr.new("192.168.0.0/16"),
+  IPAddr.new("::1/128"),
+  IPAddr.new("fc00::/7"),
+].freeze
+```
+
+## Rate Limiting (Rails 7.2+)
+
+```ruby
+rate_limit to: 10, within: 15.minutes, only: :create
+```
+
+Essential for: auth endpoints, resource creation, webhook dispatch.
+
+## Authorization Pattern
+
+```ruby
+# Controller checks
+before_action :ensure_can_administer
+def ensure_can_administer
+  head :forbidden unless @current_account.admin?
+end
+
+# Model defines — simple predicate methods, no Pundit
+class Account
+  def can_edit_habit?(habit)
+    habit.account_id == self.id
+  end
+end
+```
+
+## Multi-Tenancy Security
+
+- **Scope all queries** through `@current_account` — never trust client-provided IDs
+- Every private controller inherits `ActiveAndAuthorized` which sets `@current_account`
+- Return 404 (not 403) for resources belonging to other accounts — don't leak existence
+
+## Webhook Signatures (HMAC-SHA256)
+
+```ruby
+def sign(payload, timestamp:)
+  data = "#{timestamp}.#{payload}"
+  OpenSSL::HMAC.hexdigest("SHA256", signing_secret, data)
+end
+```
+
+## Specific Error Classes
+
+```ruby
+class Subscription::InactiveError < StandardError; end
+
+def check_subscription
+  raise Subscription::InactiveError unless @current_account.subscription_active?
+end
+
+# Controller
+rescue_from Subscription::InactiveError do
+  render json: { error: "Subscription required" }, status: :payment_required
+end
+```
+
+## API-Specific Concerns
+
+- **CORS**: Configure `rack-cors` with explicit origins, not `*`
+- **JSON-only**: Reject non-JSON content types
+- **Parameter filtering**: Log sanitization for sensitive fields (tokens, passwords)
+- **JWT expiration**: Short-lived tokens (24h), no refresh token without rotation
+
+## Key Principles
+
+1. Scope all queries through current account
+2. Rate limit auth and creation endpoints
+3. Authorization as model predicates, not policy objects
+4. 404 over 403 for cross-tenant access
+5. HMAC signatures for webhooks
+6. Specific error classes with meaningful HTTP status codes

--- a/docs/compass/testing.md
+++ b/docs/compass/testing.md
@@ -1,0 +1,94 @@
+# Testing
+
+> RSpec with FactoryBot (project convention). Patterns from 37signals adapted.
+
+**Note**: This project uses RSpec + FactoryBot (not Minitest + Fixtures as 37signals does).
+The principles below still apply regardless of framework.
+
+## Test the Behavior, Not the Implementation
+
+Assert what the user sees (responses, JSON payloads) not internal state.
+Test public interfaces, not private methods.
+
+```ruby
+# Good — tests behavior
+it "closes the card" do
+  post close_card_path(card), headers: auth_headers
+  expect(card.reload).to be_closed
+end
+
+# Bad — tests implementation
+it "creates a closure record" do
+  expect { post close_card_path(card) }.to change(Closure, :count).by(1)
+end
+```
+
+## Test Structure: Setup, Action, Assertion
+
+```ruby
+describe "POST /api/v1/habits" do
+  let(:account) { create(:account) }
+  let(:headers) { auth_headers_for(account) }
+
+  it "creates a habit" do
+    post api_v1_habits_path, params: { habit: valid_params }, headers: headers
+
+    expect(response).to have_http_status(:created)
+    expect(json_response["title"]).to eq("Exercise")
+  end
+end
+```
+
+## Integration Tests Cover the Full Stack
+
+- Happy path
+- Authentication (missing/invalid token)
+- Authorization (wrong account)
+- Validation errors
+- Edge cases
+
+## Testing Time
+
+```ruby
+it "expires after 15 minutes" do
+  travel_to 16.minutes.from_now do
+    expect(magic_link).to be_expired
+  end
+end
+```
+
+## VCR for External APIs
+
+```ruby
+VCR.configure do |config|
+  config.cassette_library_dir = "spec/vcr_cassettes"
+  config.hook_into :webmock
+  config.filter_sensitive_data('<API_KEY>') { ENV['STRIPE_API_KEY'] }
+end
+```
+
+To update cassettes: `VCR_RECORD=1 bundle exec rspec`
+
+## Testing Jobs
+
+```ruby
+it "enqueues notification job" do
+  expect {
+    create(:habit_check, habit: habit)
+  }.to have_enqueued_job(NotifyJob)
+end
+```
+
+## Don't Let Tests Shape Design
+
+- Avoid test-induced design damage
+- Never add code just for testability
+- Tests ship with features, same commit
+
+## Key Principles
+
+1. Test behavior, not implementation
+2. Integration tests for full stack coverage
+3. VCR for external APIs — fast, deterministic, offline
+4. Tests ship with features — no test debt
+5. Keep tests fast — mock external, parallelize

--- a/docs/compass/webhooks.md
+++ b/docs/compass/webhooks.md
@@ -1,0 +1,123 @@
+# Webhooks
+
+> SSRF protection, HMAC signatures, delinquency tracking.
+
+## SSRF Protection
+
+Prevent webhooks from hitting internal services:
+
+```ruby
+module SsrfProtection
+  DISALLOWED_IP_RANGES = [
+    IPAddr.new("127.0.0.0/8"), IPAddr.new("10.0.0.0/8"),
+    IPAddr.new("172.16.0.0/12"), IPAddr.new("192.168.0.0/16"),
+    IPAddr.new("169.254.0.0/16"), IPAddr.new("::1/128"),
+  ].freeze
+
+  # Resolve DNS once, pin to that IP (prevents DNS rebinding)
+  def perform_safe_request(url, **options)
+    uri = URI.parse(url)
+    resolved_ip = Resolv.getaddress(uri.host)
+    validate_ip!(resolved_ip)
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.ipaddr = resolved_ip  # Pin to resolved IP
+    http.open_timeout = 5
+    http.read_timeout = 10
+    http.request(build_request(uri, **options))
+  end
+end
+```
+
+## Delivery State Machine
+
+```ruby
+class Webhook::Delivery < ApplicationRecord
+  enum :status, { pending: 0, delivered: 1, failed: 2, timed_out: 3, error: 4 }
+
+  store :request, accessors: %i[request_url request_headers request_body], coder: JSON
+  store :response, accessors: %i[response_code response_headers response_body], coder: JSON
+
+  MAX_RESPONSE_SIZE = 50.kilobytes
+end
+```
+
+## HMAC-SHA256 Signatures
+
+```ruby
+class Webhook < ApplicationRecord
+  has_secure_token :signing_secret
+
+  def sign(payload, timestamp:)
+    data = "#{timestamp}.#{payload}"
+    OpenSSL::HMAC.hexdigest("SHA256", signing_secret, data)
+  end
+end
+```
+
+Headers: `X-Webhook-Signature` + `X-Webhook-Timestamp`
+
+## Delinquency Tracking
+
+Track consecutive failures, pause after threshold:
+
+```ruby
+class Webhook::DelinquencyTracker
+  DELINQUENCY_THRESHOLD = 10
+  DELINQUENCY_DURATION = 1.hour
+
+  def record_delivery_of(delivery)
+    delivery.delivered? ? reset : increment
+  end
+
+  private
+  def increment
+    webhook.increment!(:consecutive_failures)
+    if webhook.consecutive_failures >= DELINQUENCY_THRESHOLD
+      webhook.update!(delinquent_until: DELINQUENCY_DURATION.from_now)
+    end
+  end
+end
+```
+
+## Two-Stage Job Pattern
+
+1. **Dispatch job** finds matching webhooks
+2. **Delivery job** handles each individually
+
+```ruby
+class WebhookDispatchJob < ApplicationJob
+  def perform(event:, deliverable:)
+    webhooks = deliverable.account.webhooks.active
+    webhooks.find_each do |webhook|
+      delivery = webhook.deliveries.create!(event: event, status: :pending)
+      Webhook::DeliveryJob.perform_later(delivery)
+    end
+  end
+end
+```
+
+## Data Retention
+
+```ruby
+scope :stale, -> { where(created_at: ...7.days.ago) }
+# Purge via recurring job
+```
+
+## URL Validation
+
+```ruby
+validates :url, presence: true, format: { with: /\Ahttps:\/\//i, message: "must use HTTPS" }
+validate :url_is_not_private  # DNS resolve + check against DISALLOWED_IP_RANGES
+```
+
+## Key Principles
+
+1. **SSRF protection** — resolve DNS upfront, pin IP, block private ranges
+2. **State machine** — track pending/delivered/failed/timed_out/error
+3. **Delinquency** — pause after 10 consecutive failures for 1 hour
+4. **HMAC signatures** — sign `timestamp.payload`, include both headers
+5. **Short timeouts** — 5s open / 10s read
+6. **Response size limits** — truncate to prevent DB bloat
+7. **HTTPS only** — validate at save time
+8. **Automatic cleanup** — purge deliveries older than 7 days

--- a/docs/compass/what-they-avoid.md
+++ b/docs/compass/what-they-avoid.md
@@ -1,0 +1,75 @@
+# What to Avoid
+
+> Gems and abstractions 37signals deliberately skips — with project-specific exceptions.
+
+## Minimal Service Objects
+
+37signals says: put behavior on the model, not in service objects.
+
+**Project exception**: This project uses **Trailblazer Operations** (`app/operations/`) for multi-step business logic with validation contracts. This is an intentional architectural choice — Operations handle orchestration (validate → build → assign → save) while models stay focused on domain behavior.
+
+```ruby
+# Trailblazer Operation — orchestration layer
+class Habits::Create < Trailblazer::Operation
+  step :validate
+  step :build_habit
+  step :assign_account
+  step :save
+end
+
+# Model — domain behavior
+class Habit
+  def check!(date:)
+    # business logic lives here
+  end
+end
+```
+
+**Rule of thumb**: Simple CRUD → model methods. Multi-step workflows with validation → Operations.
+
+## No Pundit/CanCanCan
+
+Simple predicate methods on models:
+
+```ruby
+class Account
+  def owns?(habit)
+    habit.account_id == self.id
+  end
+end
+```
+
+Authorization is domain logic. It belongs on the model.
+
+## No Decorators/Presenters
+
+For APIs, serialize in the controller or use a simple method on the model:
+
+```ruby
+class Habit
+  def as_json(*)
+    super(only: [:id, :title, :rrule, :status])
+  end
+end
+```
+
+## No GraphQL
+
+REST endpoints. If you need flexible queries, add query parameters.
+
+## No Devise
+
+Custom JWT auth in a concern. See [authentication.md](authentication.md).
+
+## No ActiveRecord (by design)
+
+This project uses **MongoDB/Mongoid**. No migrations, no `schema.rb`, no SQL. Embrace the document model — embedded docs, schemaless flexibility, atomic operations.
+
+## The Philosophy
+
+> "The best code is no code at all. The second best is code that uses what's already there."
+
+Every dependency is a liability. Every abstraction layer is a place where bugs hide.
+Write the simplest thing that could possibly work.
+
+**Exception**: When an abstraction has already proven its value in the project (like Trailblazer for complex operations, or Dry-Validation for contracts), keep using it consistently rather than mixing approaches.


### PR DESCRIPTION
## Summary

- Add `docs/compass/` — 37signals patterns adapted for Rails API + MongoDB/Mongoid, frontend-only guides removed (Stimulus, CSS, Hotwire)
- Add `docs/architecture-refactor.md` — gap analysis of the current codebase against the compass, with identified security issues and a 7-phase execution plan

## Compass (docs/compass/)

Guides included: `philosophy`, `models`, `controllers`, `routing`, `authentication`, `multi-tenancy`, `database`, `background-jobs`, `filtering`, `performance`, `security`, `webhooks`, `testing`, `observability`, `what-they-avoid`

Adaptations for this project:
- Mongoid instead of ActiveRecord/PostgreSQL
- JWT + SIWE instead of cookie sessions
- Sidekiq instead of Solid Queue
- Trailblazer Operations documented as a justified exception (to be removed — see refactor plan)

## Refactor Plan (docs/architecture-refactor.md)

**Security issues identified:**
- `HabitsCategoryController` — update/destroy without tenant scoping (any authenticated user can edit/delete other accounts' categories)
- JWT without expiration (`exp` claim missing)
- `rescue Exception` in `siwe_verify` catches system-level errors
- `WEBHOOK_SECRET` as a file-level global constant

**Architectural decisions:**
| Decision | Outcome |
|---------|-----------|
| Soft deletes (Paranoia) | Keep |
| StripeService wrapper | Remove — call `Stripe::*` directly |
| Trailblazer Operations | Remove — move logic to model methods |
| AuthController | Keep 1 controller, extract logic to `Account` model |

**Plan:** 7 phases, starting with security (Phase 1).

## Test plan

- [ ] Review compass guides against project patterns
- [ ] Review refactor plan and prioritize phases
- [ ] Confirm architectural decisions before starting implementation